### PR TITLE
Add transformation utility and associated, mysteriously-failing test

### DIFF
--- a/src/api/__tests__/transformations.test.js
+++ b/src/api/__tests__/transformations.test.js
@@ -1,0 +1,67 @@
+import { simplifyAggregations } from '../transformations';
+
+const json = {
+  aggregations: {
+    '9f27d5a6ed65c4938ede65e536e5f6d4': {
+      mc: {
+        'c873a345-185c-cdb1-aeeb-32b04cf4fc9a': {
+          question: 'Which issue should be highest on the new presidentâ€™s agenda?',
+          answers: {
+            'b1cc14fffa31a73de64ba82e99ecfbe6': {
+              answer: 'Social Issues',
+              count: 2
+            },
+            '98a6399d1a49d929e8403bf9fce897e5': {
+              answer: 'The Economy',
+              count: 1
+            }
+          }
+        }
+      },
+      count: 3
+    },
+    'd1bccc85fc14440d4201e4fa2a7a88a2': {
+      mc: {
+        'c873a345-185c-cdb1-aeeb-32b04cf4fc9a': {
+          question: 'Which issue should be highest on the new presidentâ€™s agenda?',
+          answers: {
+            'd91b20b62997b6bfe27473dd16675cfb': {
+              answer: 'Energy and the Environment',
+              count: 1
+            },
+            'de7a22a0c94aa64ba2449e520aa20c99': {
+              answer: 'Education',
+              count: 1
+            }
+          }
+        }
+      },
+      count: 2
+    }
+  }
+};
+
+describe('API transformation utilities', () => {
+
+  describe('simplifyAggregations', () => {
+    const result = simplifyAggregations(json.aggregations);
+    expect(result).not.toEqual(json.aggregations);
+    expect(result).toEqual({
+      '9f27d5a6ed65c4938ede65e536e5f6d4': {
+        'c873a345-185c-cdb1-aeeb-32b04cf4fc9a': {
+          'b1cc14fffa31a73de64ba82e99ecfbe6': 2,
+          '98a6399d1a49d929e8403bf9fce897e5': 1
+        },
+        count: 3
+      },
+      'd1bccc85fc14440d4201e4fa2a7a88a2': {
+        'c873a345-185c-cdb1-aeeb-32b04cf4fc9a': {
+          'd91b20b62997b6bfe27473dd16675cfb': 1,
+          'de7a22a0c94aa64ba2449e520aa20c99': 1
+        },
+        count: 2
+      }
+    });
+  });
+
+});

--- a/src/api/transformations.js
+++ b/src/api/transformations.js
@@ -1,6 +1,55 @@
-export function keyedToArray(arr) {
-  console.log(arr);
-  const questions = Object.keys(arr.aggregations).map(key => arr.aggregations[key]);
-  console.log(questions);
-  return questions;
-}
+/**
+ * Convert a full nested aggregations object into a simpler subset that
+ * can be more easily queried for specific results, by removing intermediate
+ * keys.
+ *
+ * The resulting format is
+ *
+ * [Grouping Q Answer ID][ID of non-grouping MC Q][Answer ID from that MC Q]: count
+ *
+ * Original JSON:
+ *
+ *     "aggregations": {
+ *       "9f27d5a6ed65c4938ede65e536e5f6d4": {
+ *         "mc": {
+ *           "c873a345-185c-cdb1-aeeb-32b04cf4fc9a": {
+ *             "question": "Which issue should be highest on the new presidentâ€™s agenda?",
+ *             "answers": {
+ *               "b1cc14fffa31a73de64ba82e99ecfbe6": {
+ *                 "answer": "Social Issues",
+ *                 "count": 2
+ *
+ * Revised JSON:
+ *
+ *     "aggregations": {
+ *       [groupKey]
+ *       "9f27d5a6ed65c4938ede65e536e5f6d4": {
+ *         [mcQId]
+ *         "c873a345-185c-cdb1-aeeb-32b04cf4fc9a": {
+ *           [answerId]
+ *           "b1cc14fffa31a73de64ba82e99ecfbe6": 2
+ *
+ * @param {Object} aggregations The aggregations property of the root JSON file
+ * @returns {Object} A simplified aggregations object
+ */
+export const simplifyAggregations = aggregations => Object.keys(aggregations)
+  .reduce((carry, groupKey) => {
+    const group = aggregations[groupKey];
+
+    // Create a new object with the key "count", and with a string key for
+    // each non-grouping multiple choice question ID
+    return Object.assign(carry, {
+      // Keyed by Answer ID for the Grouping Question
+      [groupKey]: Object.keys(group.mc)
+        .reduce((carry, mcQId) => Object.assign(carry, {
+          // Keyed by Non-Grouping Multiple Choice Question Id
+          [mcQId]: Object.keys(group.mc[mcQId].answers)
+            .reduce((carry, answerId) => Object.assign(carry, {
+              // Keyed by Answer ID for that Multiple Choice Question
+              [answerId]: group.mc[mcQId].answers[answerId].count
+            }), {})
+        }), {
+          count: group.count
+        })
+    });
+  }, {});


### PR DESCRIPTION
When I run `npm test`, I get a failure on this spec because

```
  ● API transformation utilities › simplifyAggregations › encountered a declaration exception

    'expect' was used when there was no current spec, this could be because an asynchronous test timed out

      at global.expect.actual (node_modules/jest-jasmine2/build/extendJasmineExpect.js:23:29)
      at Suite.<anonymous> (src/api/__tests__/transformations.test.js:48:5)
      at Suite.<anonymous> (src/api/__tests__/transformations.test.js:46:3)
      at Object.<anonymous> (src/api/__tests__/transformations.test.js:44:1)
```

Nothing about `simplifyAggregations` is asynchronous; what am I missing, that this test fails in this way?
