### PR TITLE
Better emoji markup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,18 +6,6 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
     <title>Election Reactions 2016</title>
-    <script>
-    if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
-      var msViewportStyle = document.createElement("style");
-      msViewportStyle.appendChild(
-        document.createTextNode(
-          "@-ms-viewport{width:auto!important}"
-        )
-      );
-      document.getElementsByTagName("head")[0].
-        appendChild(msViewportStyle);
-    }
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -36,7 +36,7 @@ p {
   margin-bottom: 0;
 }
 
-@media only screen and (min-width: 25em) {  
+@media only screen and (min-width: 25em) {
   .container {
     padding: 2em;
     margin: auto;
@@ -48,7 +48,7 @@ p {
   }
 }
 
-@media only screen and (min-width: 40em) { 
+@media only screen and (min-width: 40em) {
   .container {
     padding: 2.5em;
   }
@@ -56,4 +56,16 @@ p {
   .container > div {
     margin-bottom: 2.5em;
   }
+}
+
+// button elements have no intrinsic style so that they may be used
+// as interactable containers within visualizations. To get visual
+// button styling, use `<button className="button">`
+button {
+  -webkit-appearance: none;
+  background-color: transparent;
+  border: 0;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }

--- a/src/assets/skeleton/skeleton.css
+++ b/src/assets/skeleton/skeleton.css
@@ -166,7 +166,6 @@ a:hover {
 /* Buttons
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .button,
-button,
 input[type="submit"],
 input[type="reset"],
 input[type="button"] {
@@ -188,12 +187,10 @@ input[type="button"] {
   cursor: pointer;
   box-sizing: border-box; }
 .button:hover,
-button:hover,
 input[type="submit"]:hover,
 input[type="reset"]:hover,
 input[type="button"]:hover,
 .button:focus,
-button:focus,
 input[type="submit"]:focus,
 input[type="reset"]:focus,
 input[type="button"]:focus {
@@ -201,7 +198,6 @@ input[type="button"]:focus {
   border-color: #888;
   outline: 0; }
 .button.button-primary,
-button.button-primary,
 input[type="submit"].button-primary,
 input[type="reset"].button-primary,
 input[type="button"].button-primary {
@@ -209,7 +205,6 @@ input[type="button"].button-primary {
   background-color: #33C3F0;
   border-color: #33C3F0; }
 .button.button-primary:hover,
-button.button-primary:hover,
 input[type="submit"].button-primary:hover,
 input[type="reset"].button-primary:hover,
 input[type="button"].button-primary:hover,

--- a/src/components/EmojiBarChart.js
+++ b/src/components/EmojiBarChart.js
@@ -133,8 +133,7 @@ class EmojiBarChart extends PureComponent {
           <span className="selectedTopic"> {topic} </span>
           feel:
         </p>
-        <div className="emoji-bar-wrapper" ref={(node) => { this.root = node; }}
-        />
+        <div className="emoji-bar-wrapper" ref={(node) => { this.root = node; }} />
       </div>
     );
   }

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -1,19 +1,52 @@
-.emojis-bubble-chart {
+$transition-speed-in: 50ms;
+$transition-speed-out: 200ms;
 
-  .emoji {
+.emojis-bubble-chart {
+  position: relative;
+  border: 1px solid red;
+
+  .emoji-container {
     position: absolute;
     cursor: pointer;
     text-align: center;
-    transition: width 200ms, height 200ms, left 200ms;
+    transition: width 200ms, height 200ms;
+    > img {
+      max-width: 90%;
+    }
+
+    &:hover,
+    &.selected {
+      .emoji-image {
+        margin: -2px;
+        transition: margin $transition-speed-out;
+      }
+      .emoji-label {
+        top: 100%;
+        font-size: 0.7em;
+        transition: top $transition-speed-out, font-size $transition-speed-out;
+      }
+    }
+  }
+
+  .emoji-image {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: block;
+    transition: margin $transition-speed-in;
+    margin: 0;
   }
 
   .emoji-label {
     position: absolute;
-    text-align: center;
+    margin: auto;
+    top: 98%;
+    left: 0;
+    width: 100%;
+    display: inline-block;
+    font-size: 0.8em;
+    transition: top $transition-speed-in, font-size $transition-speed-in;
   }
 }
-
-.emojis-bubble-chart > div {
-  margin: auto;
-}
-

--- a/src/components/FilterableBarChart.js
+++ b/src/components/FilterableBarChart.js
@@ -49,7 +49,6 @@ class FilterableBarChart extends PureComponent {
         topics={questionOptions}
         selectedEmoju={selectedEmoji}
         selectedTopic={selectedTopic}
-        width={400}
       />
     );
   }

--- a/src/components/FilterableBarChart.js
+++ b/src/components/FilterableBarChart.js
@@ -3,30 +3,38 @@ import { connect } from 'react-redux';
 
 import TopicBarChart from '../components/TopicBarChart';
 
+import { selectTopic } from '../state/actions';
+
 import {
   getAggregations,
   getMultipleChoiceCounts,
-  getSelectedEmoji
+  getSelectedEmoji,
+  getSelectedTopic
 } from '../state/selectors';
 
 const mapStateToProps = state => ({
   aggregations: getAggregations(state),
   mcQuestions: getMultipleChoiceCounts(state),
-  selectedEmoji: getSelectedEmoji(state)
+  selectedEmoji: getSelectedEmoji(state),
+  selectedTopic: getSelectedTopic(state)
 });
 
 class FilterableBarChart extends PureComponent {
   static propTypes = {
     questionId: PropTypes.string,
     mcQuestions: PropTypes.object,
-    selectedEmoji: PropTypes.object
+    selectedEmoji: PropTypes.object,
+    selectedTopic: PropTypes.object,
+    dispatch: PropTypes.func
   }
 
   render() {
     const {
-      questionId,
       mcQuestions,
-      selectedEmoji
+      questionId,
+      selectedEmoji,
+      selectedTopic,
+      dispatch
     } = this.props;
 
     if (!questionId || !mcQuestions) {
@@ -36,7 +44,13 @@ class FilterableBarChart extends PureComponent {
     const questionOptions = mcQuestions[questionId];
 
     return (
-      <TopicBarChart topics={questionOptions} selected={selectedEmoji} width={400} />
+      <TopicBarChart
+        onSelect={topicId => dispatch(selectTopic(topicId))}
+        topics={questionOptions}
+        selectedEmoju={selectedEmoji}
+        selectedTopic={selectedTopic}
+        width={400}
+      />
     );
   }
 }

--- a/src/components/TopicBarChart.js
+++ b/src/components/TopicBarChart.js
@@ -4,7 +4,6 @@ import { inlineEmoji } from '../utils/emoji';
 
 import './TopicBarChart.scss';
 
-
 class TopicBarChart extends PureComponent {
   static propTypes = {
     topics: PropTypes.array,

--- a/src/components/TopicBarChart.js
+++ b/src/components/TopicBarChart.js
@@ -8,12 +8,20 @@ import './TopicBarChart.scss';
 class TopicBarChart extends PureComponent {
   static propTypes = {
     topics: PropTypes.array,
-    selected: PropTypes.object,
+    selectedEmoji: PropTypes.object,
+    selectedTopic: PropTypes.object,
+    onSelect: PropTypes.func,
     width: PropTypes.number
   }
 
   render() {
-    const { topics, selected, width } = this.props;
+    const {
+      onSelect,
+      selectedEmoji,
+      selectedTopic,
+      topics,
+      width
+    } = this.props;
 
     const containerStyles = width ? {
       maxWidth: `${width}px`
@@ -25,7 +33,7 @@ class TopicBarChart extends PureComponent {
 
     const responseCount = d3.sum(topics, d => d.count);
 
-    const emojiImageElement = selected && inlineEmoji(selected.answer);
+    const emojiImageElement = selectedEmoji && inlineEmoji(selectedEmoji.answer);
 
     /* eslint-disable no-confusing-arrow */
     const pluralizePeople = count => (count === 1) ? 'person' : 'people';
@@ -39,16 +47,21 @@ class TopicBarChart extends PureComponent {
         </p>
         <div className="bar-group-container">
           <p className="note">
-            {selected && `${responseCount} ${pluralizePeople(responseCount)} said `}
-            {selected && emojiImageElement}
-            {!selected && `${responseCount} total responses`}
+            {selectedEmoji && `${responseCount} ${pluralizePeople(responseCount)} said `}
+            {selectedEmoji && emojiImageElement}
+            {!selectedEmoji && `${responseCount} total responses`}
           </p>
           {topics.map((topic) => {
             const percentage = topic.count ?
               d3.format('.0%')(topic.count / responseCount) :
               0;
             return (
-              <div key={topic.answer} className="bar-group">
+              <button
+                aria-pressed={selectedTopic && (topic.id === selectedTopic.id)}
+                onClick={() => onSelect(topic.id)}
+                key={topic.answer}
+                className="bar-group"
+              >
                 <div className="topic-detail-container">
                   <div className="topic-name">{topic.answer}</div>
                   <div className="percentage">{percentage}</div>
@@ -56,7 +69,7 @@ class TopicBarChart extends PureComponent {
                 <div className="topic-bar-container">
                   <div className="topic-bar" style={{ width: percentage }} />
                 </div>
-              </div>
+              </button>
             );
           })}
         </div>

--- a/src/components/TopicBarChart.js
+++ b/src/components/TopicBarChart.js
@@ -10,8 +10,7 @@ class TopicBarChart extends PureComponent {
     topics: PropTypes.array,
     selectedEmoji: PropTypes.object,
     selectedTopic: PropTypes.object,
-    onSelect: PropTypes.func,
-    width: PropTypes.number
+    onSelect: PropTypes.func
   }
 
   render() {
@@ -19,13 +18,8 @@ class TopicBarChart extends PureComponent {
       onSelect,
       selectedEmoji,
       selectedTopic,
-      topics,
-      width
+      topics
     } = this.props;
-
-    const containerStyles = width ? {
-      maxWidth: `${width}px`
-    } : null;
 
     if (!topics || !topics.length) {
       return null;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -68,7 +68,7 @@ class App extends Component {
             selectedEmoji={selectedEmoji}
             onSelect={emoji => dispatch(selectEmoji(emoji))}
             width={400}
-            height={300}
+            height={400}
           />}
           {/*
             emojiQuestion && <EmojiGrid questionKey={emojiQuestion.id} responses={responses} width={400} height={300} />

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -19,14 +19,14 @@ import {
   getAggregations,
   getEmojiCounts,
   // getEmojiQuestion,
-  getMultipleChoiceCounts
+  getMultipleChoiceCounts,
   // getResponsesList,
-  // getSelectedEmoji
+  getSelectedEmoji
 } from '../state/selectors';
 
 const mapStateToProps = state => ({
   emoji: getEmojiCounts(state),
-  // selectedEmoji: getSelectedEmoji(state),
+  selectedEmoji: getSelectedEmoji(state),
   // emojiQuestion: getEmojiQuestion(state),
   mcQuestions: getMultipleChoiceCounts(state),
   // responses: getResponsesList(state),
@@ -40,7 +40,7 @@ class App extends Component {
     // emojiQuestion: PropTypes.object,
     // responses: PropTypes.array,
     mcQuestions: PropTypes.object,
-    // selectedEmoji: PropTypes.object,
+    selectedEmoji: PropTypes.object,
     dispatch: PropTypes.func
   }
 
@@ -55,7 +55,7 @@ class App extends Component {
       emoji,
       // responses,
       aggregations,
-      // selectedEmoji,
+      selectedEmoji,
       // emojiQuestion,
       mcQuestions,
       dispatch
@@ -65,6 +65,7 @@ class App extends Component {
         <div className="container">
           {emoji && <EmojiBubbleChart
             emoji={emoji}
+            selectedEmoji={selectedEmoji}
             onSelect={emoji => dispatch(selectEmoji(emoji))}
             width={400}
             height={300}

--- a/src/state/__tests__/reducer.selected.test.js
+++ b/src/state/__tests__/reducer.selected.test.js
@@ -16,35 +16,73 @@ describe('reducers', () => {
 
     it('sets the correct default state', () => {
       const result = selected(undefined, irrelevantAction);
-      expect(result).toBeNull();
+      expect(result).toEqual({
+        emoji: null,
+        topic: null
+      });
     });
 
     it('is represented in the combined default state', () => {
-      expect(combinedReducerDefaultState.selected).toBeNull();
+      expect(combinedReducerDefaultState.selected).toEqual({
+        emoji: null,
+        topic: null
+      });
     });
 
     it('can set the selected emoji', () => {
-      const result = selected(null, {
+      const result = selected({}, {
         type: 'SELECT_EMOJI',
         payload: '✨'
       });
-      expect(result).toBe('✨');
+      expect(result.emoji).toBe('✨');
     });
 
     it('can change the selected emoji', () => {
-      const result = selected('✨', {
+      const result = selected({
+        emoji: '✨'
+      }, {
         type: 'SELECT_EMOJI',
         payload: '❄'
       });
-      expect(result).toBe('❄');
+      expect(result.emoji).toBe('❄');
     });
 
     it('can deselect the current emoji', () => {
-      const result = selected('✨', {
+      const result = selected({
+        emoji: '✨'
+      }, {
         type: 'SELECT_EMOJI',
         payload: '✨'
       });
-      expect(result).toBe(null);
+      expect(result.emoji).toBe(null);
+    });
+
+    it('can set the selected topic', () => {
+      const result = selected({}, {
+        type: 'SELECT_TOPIC',
+        payload: 'Education'
+      });
+      expect(result.topic).toBe('Education');
+    });
+
+    it('can change the selected topic', () => {
+      const result = selected({
+        topic: 'Education'
+      }, {
+        type: 'SELECT_TOPIC',
+        payload: 'Economy'
+      });
+      expect(result.topic).toBe('Economy');
+    });
+
+    it('can deselect the current topic', () => {
+      const result = selected({
+        topic: 'Education'
+      }, {
+        type: 'SELECT_TOPIC',
+        payload: 'Education'
+      });
+      expect(result.topic).toBe(null);
     });
   });
 

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -13,6 +13,7 @@ export const receiveQuestions = createAction('RECEIVE_QUESTIONS');
  * Action creator for selecting an emoji filter. Identity used for payload
  */
 export const selectEmoji = createAction('SELECT_EMOJI');
+export const selectTopic = createAction('SELECT_TOPIC');
 
 /**
  * Action creator to fetch questions (form digest) from the API

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -35,12 +35,30 @@ export const questions = handleActions({
 
 export const selected = handleActions({
   SELECT_EMOJI: (state, action) => {
-    if (state === action.payload) {
-      return null;
+    if (state.emoji === action.payload) {
+      return Object.assign({}, state, {
+        emoji: null
+      });
     }
-    return action.payload;
+    return Object.assign({}, state, {
+      emoji: action.payload
+    });
+  },
+
+  SELECT_TOPIC: (state, action) => {
+    if (state.topic === action.payload) {
+      return Object.assign({}, state, {
+        topic: null
+      });
+    }
+    return Object.assign({}, state, {
+      topic: action.payload
+    });
   }
-}, null);
+}, {
+  emoji: null,
+  topic: null
+});
 
 export const responses = handleActions({
   // Not yet called

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -42,13 +42,13 @@ export const getMultipleChoiceCounts = createSelector(
   getMultipleChoiceQuestions,
   getSelected,
   getAggregations,
-  (mcQuestions, selectedEmojiId, aggregations) => Object.keys(mcQuestions).reduce((carry, key) => {
+  (mcQuestions, selected, aggregations) => Object.keys(mcQuestions).reduce((carry, key) => {
     const question = mcQuestions[key];
     const optionsWithCounts = question.options.map((option) => {
       let optionCount = 0;
 
-      if (selectedEmojiId) {
-        optionCount = aggregations[selectedEmojiId][question.id][option.id];
+      if (selected.emoji) {
+        optionCount = aggregations[selected.emoji][question.id][option.id];
       } else if (aggregations) {
         optionCount = Object.keys(aggregations)
           .reduce((count, groupKey) => {
@@ -106,5 +106,21 @@ export const getEmojiCounts = createSelector(
 export const getSelectedEmoji = createSelector(
   getEmojiQuestion,
   getSelected,
-  (question, selectedEmojiId) => question && question.options.find(option => option.id === selectedEmojiId)
+  (question, selected) => question && question.options.find(option => option.id === selected.emoji)
+);
+
+export const getSelectedTopic = createSelector(
+  getMultipleChoiceQuestions,
+  getSelected,
+  (mcQuestions, selected) => {
+    const questionIds = Object.keys(mcQuestions);
+    for (let i = 0; i < questionIds.length; i += 1) {
+      const question = mcQuestions[questionIds[i]];
+      const match = question && question.options.find(option => option.id === selected.topic);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
 );

--- a/src/utils/emoji.js
+++ b/src/utils/emoji.js
@@ -16,18 +16,21 @@ export const emojiSVGUrl = (emojiUnicode) => {
   return emojiUrl;
 };
 
-export const inlineEmoji = (emojiUnicode) => {
+export const emojiSVGImageTag = emojiUnicode => twemoji
+  .parse(emojiUnicode, icon => emojiSVGUrl(icon));
+
+export const inlineEmoji = (emojiUnicode, props) => {
   if (!emojiUnicode) {
     return null;
   }
 
   const html = {
-    __html: twemoji.parse(emojiUnicode, icon => emojiSVGUrl(icon))
+    __html: emojiSVGImageTag(emojiUnicode)
   };
 
   /* eslint-disable react/no-danger */
   return (
-    <span dangerouslySetInnerHTML={html} />
+    <span {...props} dangerouslySetInnerHTML={html} />
   );
   /* eslint-enable react/no-danger */
 };


### PR DESCRIPTION
**Make Topic selectable in Bar Chart**
- Uses `<button>` element for the clickable elements
- Adds reducers so that the topic may be selected
- _does not yet de-couple the bubble & topic charts_; that is TK

**Use React to lay out and render bubble chart:**
- Switches transitions to CSS, not D3
- Uses React to render the DOM
- Uses `<button>` elements for the clickable elements
- Adds an aria-pressed attribute to pressed toggle items
- Made bubble chart fixed-aspect-ratio responsive:

![emoji-bubbles](https://cloud.githubusercontent.com/assets/442115/19779327/9c98aa20-9c4e-11e6-8ca8-0b497c3b3f97.gif)
