### PR TITLE
Revert "Remove no-longer-needed WP 8.0 width fix"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,18 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
     <title>Election Reactions 2016</title>
+    <script>
+    if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+      var msViewportStyle = document.createElement("style");
+      msViewportStyle.appendChild(
+        document.createTextNode(
+          "@-ms-viewport{width:auto!important}"
+        )
+      );
+      document.getElementsByTagName("head")[0].
+        appendChild(msViewportStyle);
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This reverts commit 76d85870dea9e5254cfa1dc202a45d78970b6f3d. Turns out that WP 8.0 _does_ need this, and the fact that my layout was working without it was a cached index.html fluke.
