### PR TITLE
Add external configuration file & instructions to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build
 .DS_Store
 .env
 npm-debug.log
+
+# Do not commit env-specific config
+config.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,43 @@
 
 A prototype application to visualize reactions to the outcome of the 2016 election.
 
+## Installation
+
+Copy the file `config.sample.json` in the project root to `config.json`, then set the values of each key to match your deployment.
+
+### Quick Start
+
+To get started quickly with local development, just save this JSON as `config.json` in the project root:
+
+```json
+{
+  "jsonURI": "http://localhost:3000/data/",
+  "formId": "581118892b74a9ceb5c309ab",
+  "googleSheetId": "18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I"
+}
+```
+
+### Configuration Guide
+
+**jsonURI**:
+
+This field holds the URI at which the JSON files output by Ask can be located over HTTP. For local development this will likely be "http://localhost:3000/data/", but in production it will usually be a URL to the location on Amazon S3 to which Ask uploads its JSON.
+
+**formId**:
+
+If you have a local instance of [Coral Ask](https://coralproject.net/products/ask.html) running at, say, localhost:2020, when you're editing the form you wish to use to drive this visualization you will be at a URL similar to this:
+```
+http://localhost:2020/forms/581118892b74a9ceb5c309ab
+```
+"581118892b74a9ceb5c309ab" is your formId. This ID is combined with the `jsonURI` to locate the JSON data files that will be loaded.
+
+**googleSheetId**:
+
+Editorial text fields in this visualization and the non-user-editable text of the "letter to the president" that is assembled from the responses is managed through [Google Sheets](https://sheets.google.com): create a publicly-visible spreadsheet document by duplicating [this sheet](https://docs.google.com/spreadsheets/d/18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I/edit#gid=904229865). Once your sheet is set up, copy the ID out of the spreadsheet URL; for the URL
+```
+https://docs.google.com/spreadsheets/d/18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I/edit#gid=904229865
+```
+"18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I" is your googleSheetId.
 
 ## Development
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,5 @@
+{
+  "jsonURI": "Copy the URI where the JSON files are available here",
+  "formId": "Copy the Ask form ID (e.g. 581118892b74a9ceb5c309ab) into this field",
+  "googleSheetId": "Copy the ID of the Google Spreadsheet (e.g. 18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I) here"
+}

--- a/config/paths.js
+++ b/config/paths.js
@@ -26,6 +26,7 @@ var nodePaths = (process.env.NODE_PATH || '')
 
 // config after eject: we're in ./config/
 module.exports = {
+  appConfig: resolveApp('config.json'),
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -21,6 +21,10 @@ var config = require('../config/webpack.config.dev');
 var paths = require('../config/paths');
 
 // Warn and crash if required files are missing
+if (!checkRequiredFiles([paths.appConfig])) {
+  console.log(chalk.red('\nMissing config.json. See README for instructions.'));
+  process.exit(1);
+}
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
   process.exit(1);
 }

--- a/src/api/content.js
+++ b/src/api/content.js
@@ -1,20 +1,21 @@
 import Tabletop from 'tabletop';
+import config from '../config';
 
-export function getFields() {
-  return (
-    new Promise((resolve) => {
-      Tabletop.init({
-
-        // google spreadsheet key.
-        // TODO: this will need to come from some place else
-        // since people will clone their own.
-        key: '18yAMk_ydGpPLHTZPrLox7oplvgc-4aswu1arO_IHY9I',
-        callback: (data, tb) => {
-          // extract fields, and only pass those.
-          resolve(tb.sheets('Fields').all());
-        },
-        simpleSheet: true
-      });
-    })
-  );
+/**
+ * Retrieve content from a Google Sheets Spreadsheet, which we use as as a
+ * lightweight CMS for content we can't get from Ask's JSON export
+ *
+ * @returns {Promise} A promise to a Tabletop sheets response object
+ */
+export function getContent() {
+  return new Promise((resolve) => {
+    Tabletop.init({
+      key: config.googleSheetId,
+      callback: (data, tb) => {
+        // extract fields, and only pass those.
+        resolve(tb.sheets('Fields').all());
+      },
+      simpleSheet: true
+    });
+  });
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,18 @@
+import config from '../config.json';
+
+[{
+  key: 'googleSheetId',
+  message: 'Configuration missing: Google Spreadsheet ID!'
+}, {
+  key: 'formId',
+  message: 'Configuration missing: Ask form ID!'
+}, {
+  key: 'jsonURI',
+  message: 'Configuration missing: JSON output URI!'
+}].forEach((requiredKey) => {
+  if (!config[requiredKey.key]) {
+    throw new Error(requiredKey.message);
+  }
+});
+
+export default config;

--- a/src/containers/GoogleSheetFieldComponent.js
+++ b/src/containers/GoogleSheetFieldComponent.js
@@ -7,12 +7,12 @@ import {
 } from '../state/actions';
 
 import {
-  getFieldsData
+  getContentFieldsData
 } from '../state/selectors';
 
 const mapStateToProps = state => ({
   // google spreadsheet fields
-  fields: getFieldsData(state)
+  fields: getContentFieldsData(state)
 });
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import Redbox from 'redbox-react';
 import store from './state/store';
 import Root from './containers/Root';
 
-
 ReactDOM.render(
   <AppContainer errorReporter={Redbox}>
     <Root store={store} />

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -63,7 +63,7 @@ function shouldFetchFields(state) {
  */
 const fetchFields = () => (dispatch) => {
   dispatch(requestFields());
-  return content.getFields().then(data => dispatch(receiveFields(data)));
+  return content.getContent().then(data => dispatch(receiveFields(data)));
 };
 
 /**

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -7,7 +7,7 @@ export const getResponses = state => state.responses.dictionary;
 export const getSelected = state => state.selected;
 export const getAggregations = state => state.summary.aggregations;
 export const getQuestions = state => state.questions.dictionary;
-export const getFields = state => state.fields.data;
+export const getContentFields = state => state.fields.data;
 
 export const getIsFetching = state => [
   'questions',
@@ -18,7 +18,7 @@ export const getIsFetching = state => [
 
 export const getQuestionsList = createSelector(getQuestions, objectToList);
 export const getResponsesList = createSelector(getResponses, objectToList);
-export const getFieldsData = createSelector(getFields, listToObject('field-id (don\'t change!)'));
+export const getContentFieldsData = createSelector(getContentFields, listToObject('field-id (don\'t change!)'));
 
 // This app makes an assumption only Emoji questions will be used to group_by
 export const getEmojiQuestion = createSelector(


### PR DESCRIPTION
This adds a configuration file & instructions for creating your own when installing the app. This step would happen _pre_-build at present; we can change the JSON access to be async if that is required in deployment.

PR duplicated from #28, with the unrelated changes removed and feedback from @iros incorporated into README.
