### PR TITLE
Fix letter wiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "d3-transition": "^1.0.2",
     "d3-voronoi": "^1.0.2",
     "isomorphic-fetch": "^2.2.1",
+    "node-uuid": "^1.4.7",
     "react": "^15.3.2",
     "react-computed-props": "^0.1.1",
     "react-dom": "^15.3.2",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch';
 import Tabletop from 'tabletop';
-import { simplifyAggregations } from './transformations';
+import { simplifyAggregations, applyArbitraryIds } from './transformations';
 import config from '../config';
 
 // Ensure trailing slash on the jsonURI
@@ -14,7 +14,7 @@ export function getAggregations() {
       questions: response.questions,
       count: response.aggregations.all.count,
       aggregations: simplifyAggregations(response.aggregations),
-      submissions: response.submissions
+      submissions: applyArbitraryIds(response.submissions)
     }));
 }
 

--- a/src/api/transformations.js
+++ b/src/api/transformations.js
@@ -1,3 +1,5 @@
+import uuid from 'node-uuid';
+
 /**
  * Convert a full nested aggregations object into a simpler subset that
  * can be more easily queried for specific results, by removing intermediate
@@ -60,3 +62,7 @@ export const simplifyAggregations = aggregations => Object.keys(aggregations)
         })
     });
   }, {});
+
+export const applyArbitraryIds = submissions => submissions.map(s => Object.assign({}, s, {
+  id: uuid.v1()
+}));

--- a/src/components/FilterByTopicVis.js
+++ b/src/components/FilterByTopicVis.js
@@ -12,13 +12,17 @@ import { selectTopic } from '../state/actions';
 
 import {
   getEmojiCountsFilteredByTopic,
+  getTopicQuestion,
+  getQuestionsOrder,
   getResponsesList,
   getSelectedTopic,
   getTopicCounts
 } from '../state/selectors';
 
 const mapStateToProps = state => ({
+  questionsOrder: getQuestionsOrder(state),
   selectedTopic: getSelectedTopic(state),
+  topicQuestion: getTopicQuestion(state),
   topics: getTopicCounts(state),
   filteredEmojiCounts: getEmojiCountsFilteredByTopic(state),
   responses: getResponsesList(state)
@@ -26,7 +30,9 @@ const mapStateToProps = state => ({
 
 class FilterByTopicVis extends Component {
   static propTypes = {
+    questionsOrder: PropTypes.array,
     selectedTopic: PropTypes.object,
+    topicQuestion: PropTypes.object,
     topics: PropTypes.array,
     filteredEmojiCounts: PropTypes.array,
     responses: PropTypes.array,
@@ -35,7 +41,9 @@ class FilterByTopicVis extends Component {
 
   render() {
     const {
+      questionsOrder,
       responses,
+      topicQuestion,
       topics,
       selectedTopic,
       filteredEmojiCounts,
@@ -47,8 +55,8 @@ class FilterByTopicVis extends Component {
     }
 
     const matchingResponses = selectedTopic ? where(responses, {
-      [selectedTopic.id]: selectedTopic.value
-    }) : [];
+      [topicQuestion.id]: selectedTopic.value
+    }) : responses;
 
     return (
       <div>
@@ -58,7 +66,7 @@ class FilterByTopicVis extends Component {
           selectedTopic={selectedTopic}
         />
         {selectedTopic && <EmojiBarChart height={70} emoji={filteredEmojiCounts} topic={selectedTopic} />}
-        {responses && <Letter response={responses} width={400} />}
+        <Letter responses={matchingResponses} questionsOrder={questionsOrder} width={400} />
       </div>
     );
   }

--- a/src/components/Letter.js
+++ b/src/components/Letter.js
@@ -6,28 +6,39 @@ import './Letter.scss';
 
 class Letter extends PureComponent {
   static propTypes = {
-    response: PropTypes.array
+    questionsOrder: PropTypes.array,
+    responses: PropTypes.array
   };
 
   static defaultProps = {
-    response: {}
+    responses: []
   };
 
   componentDidMount() {
-    twemoji.parse(this.root, icon => emojiSVGUrl(icon));
+    this.parseEmoji();
+  }
+
+  componentDidUpdate() {
+    this.parseEmoji();
+  }
+
+  parseEmoji() {
+    if (this.root) {
+      twemoji.parse(this.root, icon => emojiSVGUrl(icon));
+    }
   }
 
   render() {
-    let { response } = this.props;
+    const { responses, questionsOrder } = this.props;
 
-    // order significant!
-    response = [
-      { id: 'abc', answer: '😡' },
-      { id: 'wetwet', answer: 'Health Care' },
-      { id: '325jkhet', answer: 'Lowering the cost of healthcare for everyone' },
-      { id: 'ewtwg', answer: 'Irene' },
-      { id: 'wetywy', answer: 'Boston' }
-    ];
+    const response = responses[Math.floor(Math.random(responses.length))];
+
+    if (!response) {
+      return null;
+    }
+
+    // Helper method to treat the question ordering like array indexes
+    const responseField = idx => response[questionsOrder[idx]] || {};
 
     return (
       <div className={'letter'}>
@@ -37,17 +48,22 @@ class Letter extends PureComponent {
           </p>
 
           <p>
-            As you prepare to become president I am feeling <span className="emoji">{response[0].answer}</span>.
-            I think your top priority should be <span className="achieve">{response[1].answer}</span>.
+            As you prepare to become president I am feeling <span className="emoji">
+              {responseField(0)}
+            </span>.
+            I think your top priority should be <span className="achieve">
+              {responseField(1)}
+            </span>.
           </p>
           <p>
             If you achieve one thing in the next four years, I want it to
-            be: <span className="achieve">{response[2].answer}</span>.
+            be: <span className="achieve">
+              {responseField(2)}
+            </span>.
           </p>
 
           <p>
-            Thank you and good luck. <br />
-            {response[3].answer}, {response[4].answer}
+            Thank you and good luck. <br /> {responseField(3)}, {responseField(4)}
           </p>
         </div>
       </div>

--- a/src/state/__tests__/reducer.responses.test.js
+++ b/src/state/__tests__/reducer.responses.test.js
@@ -11,6 +11,7 @@ describe('reducers', () => {
   describe('responses', () => {
     const defaultState = {
       dictionary: {},
+      order: [],
       isFetching: false
     };
 
@@ -57,6 +58,11 @@ describe('reducers', () => {
           '56789': { id: '56789', sentiment: 'woo' },
           '10111': { id: '10111', sentiment: 'boo' }
         },
+        order: [
+          '01234',
+          '56789',
+          '10111'
+        ],
         isFetching: false
       });
     });

--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -92,11 +92,8 @@ const populatedState = {
     isFetching: false
   },
   responses: {
+    order: [ 'aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff' ],
     dictionary: {
-      aaa: {
-        id: 'aaa',
-        emoji: '🚌'
-      },
       bbb: {
         id: 'bbb',
         emoji: '🍩'
@@ -104,6 +101,10 @@ const populatedState = {
       ccc: {
         id: 'ccc',
         emoji: '🍸'
+      },
+      aaa: {
+        id: 'aaa',
+        emoji: '🚌'
       },
       ddd: {
         id: 'ddd',
@@ -291,35 +292,17 @@ describe('getResponsesList', () => {
     expect(getResponsesList).toBeInstanceOf(Function);
   });
 
-  it('returns an array of all available responses', () => {
+  it('returns an array of all available responses, in order', () => {
     const result = getResponsesList(populatedState);
     expect(result).toBeInstanceOf(Array);
-    // Do not depend on the ordering of object keys: validate length & contents
-    expect(result.length).toEqual(Object.keys(populatedState.responses.dictionary).length);
-    expect(result).toContainEqual({
-      id: 'aaa',
-      emoji: '🚌'
-    });
-    expect(result).toContainEqual({
-      id: 'bbb',
-      emoji: '🍩'
-    });
-    expect(result).toContainEqual({
-      id: 'ccc',
-      emoji: '🍸'
-    });
-    expect(result).toContainEqual({
-      id: 'ddd',
-      emoji: '🍸'
-    });
-    expect(result).toContainEqual({
-      id: 'eee',
-      emoji: '🍩'
-    });
-    expect(result).toContainEqual({
-      id: 'fff',
-      emoji: '🍩'
-    });
+    expect(result).toEqual([
+      { id: 'aaa', emoji: '🚌' },
+      { id: 'bbb', emoji: '🍩' },
+      { id: 'ccc', emoji: '🍸' },
+      { id: 'ddd', emoji: '🍸' },
+      { id: 'eee', emoji: '🍩' },
+      { id: 'fff', emoji: '🍩' }
+    ]);
   });
 
 });

--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -18,10 +18,18 @@ const populatedState = {
       emoji: 'emoji',
       topic: 'focus'
     },
+    order: ['emoji', 'focus', 'text'],
     dictionary: {
+      text: {
+        id: 'text',
+        type: 'TextField',
+        order: 2,
+        group_by: false
+      },
       emoji: {
         id: 'emoji',
         type: 'MultipleChoice',
+        order: 0,
         group_by: true,
         options: [
           { id: 'happy', value: '✨' },
@@ -31,6 +39,7 @@ const populatedState = {
       focus: {
         id: 'focus',
         type: 'MultipleChoice',
+        order: 1,
         group_by: true,
         options: [
           { id: 'econ', value: 'Economy' },
@@ -221,12 +230,32 @@ describe('getQuestions', () => {
     expect(result.emoji).toEqual({
       id: 'emoji',
       type: 'MultipleChoice',
+      order: 0,
       group_by: true,
       options: [
         { id: 'happy', value: '✨' },
         { id: 'hungry', value: '🍩' }
       ]
     });
+  });
+});
+
+describe('getQuestionsList', () => {
+  const { getQuestionsList } = selectors;
+
+  it('is a defined function', () => {
+    expect(getQuestionsList).toBeDefined();
+    expect(getQuestionsList).toBeInstanceOf(Function);
+  });
+
+  it('returns the proper value from the default state', () => {
+    const result = getQuestionsList(defaultState);
+    expect(result).toEqual([]);
+  });
+
+  it('returns the questions in order', () => {
+    const result = getQuestionsList(populatedState);
+    expect(result.map(result => result.id)).toEqual(['emoji', 'focus', 'text']);
   });
 });
 
@@ -411,6 +440,7 @@ describe('getEmojiQuestion', () => {
       id: 'emoji',
       type: 'MultipleChoice',
       group_by: true,
+      order: 0,
       options: [
         { id: 'happy', value: '✨' },
         { id: 'hungry', value: '🍩' }
@@ -437,6 +467,7 @@ describe('getTopicQuestion', () => {
     expect(result).toEqual({
       id: 'focus',
       type: 'MultipleChoice',
+      order: 1,
       group_by: true,
       options: [
         { id: 'econ', value: 'Economy' },

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -146,14 +146,19 @@ export const responses = handleActions({
   }),
 
   // Does not currently impact the isFetching state
-  RECEIVE_FORM_DIGEST: (state, action) => ({
-    dictionary: action.payload.submissions
-      .reduce((carry, response) => Object.assign({}, carry, {
-        [response.id]: response
-      }), state.dictionary),
-    isFetching: state.isFetching
-  })
+  RECEIVE_FORM_DIGEST: (state, action) => {
+    const { submissions } = action.payload;
+    const order = submissions.map(s => s.id);
+    const dictionary = submissions.reduce((dict, response) => Object.assign(dict, {
+      [response.id]: response
+    }), state.dictionary);
+    return Object.assign({}, state, {
+      order,
+      dictionary
+    });
+  }
 }, {
+  order: [],
   dictionary: {},
   isFetching: false
 });

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -1,6 +1,5 @@
 // Use createSelector for any reducer which returns a computed object
 import { createSelector } from 'reselect';
-import objectToList from '../utils/object-to-list';
 import listToObject from '../utils/list-to-object';
 import safeDeepAccess from '../utils/safe-deep-access';
 
@@ -9,6 +8,7 @@ export const getResponseOrder = state => state.responses.order;
 export const getSelected = state => state.selected;
 export const getAggregations = state => state.summary.aggregations;
 export const getQuestions = state => state.questions.dictionary;
+export const getQuestionsOrder = state => state.questions.order;
 export const getFilterQuestions = state => state.questions.filters;
 export const getContentFields = state => state.fields.data;
 
@@ -24,6 +24,12 @@ export const getIsFetching = state => [
   'summary',
   'fields'
 ].reduce((isFetching, storeKey) => isFetching || state[storeKey].isFetching, false);
+
+export const getQuestionsList = createSelector(
+  getQuestions,
+  getQuestionsOrder,
+  (questions, order) => order.map(id => questions[id])
+);
 
 export const getResponsesList = createSelector(
   getResponses,

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -5,6 +5,7 @@ import listToObject from '../utils/list-to-object';
 import safeDeepAccess from '../utils/safe-deep-access';
 
 export const getResponses = state => state.responses.dictionary;
+export const getResponseOrder = state => state.responses.order;
 export const getSelected = state => state.selected;
 export const getAggregations = state => state.summary.aggregations;
 export const getQuestions = state => state.questions.dictionary;
@@ -24,7 +25,12 @@ export const getIsFetching = state => [
   'fields'
 ].reduce((isFetching, storeKey) => isFetching || state[storeKey].isFetching, false);
 
-export const getResponsesList = createSelector(getResponses, objectToList);
+export const getResponsesList = createSelector(
+  getResponses,
+  getResponseOrder,
+  (responses, order) => order.map(id => responses[id])
+);
+
 export const getContentFieldsData = createSelector(getContentFields, listToObject('field-id (don\'t change!)'));
 
 export const getEmojiQuestion = createSelector(


### PR DESCRIPTION
![letter](https://cloud.githubusercontent.com/assets/442115/19801010/589c9d86-9ccb-11e6-9ccc-c0337332b20e.gif)

If responses aren't available in the initial packet they still need to be returned; de-duping between those collections may be challenging. This uses node-uuid to assign an ID to records as we originally assumed, to hold us over until we learn from @jde whether we can get an ID in the response data; otherwise we may need to de-dupe in some other fashion.
