### PR TITLE
Reinstate staggered pop-in animation

### DIFF
--- a/src/components/EmojiBubbleChart.js
+++ b/src/components/EmojiBubbleChart.js
@@ -22,6 +22,13 @@ export default class EmojiBubbleChart extends PureComponent {
     minRadius: 20
   }
 
+  componentDidUpdate() {
+    d3.selectAll('.emoji-container').each(function(d, i) {
+      const container = d3.select(this);
+      setTimeout(() => container.classed('visible', true), i * 100);
+    });
+  }
+
   render() {
     const {
       emoji,

--- a/src/components/EmojiBubbleChart.js
+++ b/src/components/EmojiBubbleChart.js
@@ -23,7 +23,7 @@ export default class EmojiBubbleChart extends PureComponent {
   }
 
   componentDidUpdate() {
-    d3.selectAll('.emoji-container').each(function(d, i) {
+    d3.selectAll('.emoji-container').each(function staggeredPopIn(d, i) {
       const container = d3.select(this);
       setTimeout(() => container.classed('visible', true), i * 100);
     });

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -1,3 +1,5 @@
+$emoji-pop-in-transition-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
+
 .emojis-bubble-chart {
   position: relative;
 
@@ -13,7 +15,6 @@
     &.visible {
       .emoji-image {
         margin: 0;
-        transition: margin 100ms;
       }
       .emoji-label {
         opacity: 1;
@@ -24,7 +25,7 @@
     &:hover,
     &.selected {
       .emoji-image {
-        margin: -2px;
+        margin: -3px;
         transition: margin 200ms;
       }
       .emoji-label {
@@ -42,7 +43,8 @@
     right: 0;
     bottom: 0;
     display: block;
-    transition: margin 500ms;
+    transition: margin 550ms $emoji-pop-in-transition-timing;
+    transition-timing-function: $emoji-pop-in-transition-timing;
     // Completely hide the image by default by compressing it down to no space
     margin: 50%;
   }
@@ -54,7 +56,7 @@
     left: 0;
     width: 100%;
     display: inline-block;
-    transition: top 100ms, font-size 100ms, opacity 100ms;
+    transition: top 200ms, font-size 200ms, opacity 200ms;
     // Completely hide the label by default; label & image are revealed by adding
     // a class to the parent container element
     opacity: 0;

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -1,6 +1,3 @@
-$transition-speed-in: 50ms;
-$transition-speed-out: 200ms;
-
 .emojis-bubble-chart {
   position: relative;
 
@@ -13,16 +10,27 @@ $transition-speed-out: 200ms;
       max-width: 90%;
     }
 
+    &.visible {
+      .emoji-image {
+        margin: 0;
+        transition: margin 100ms;
+      }
+      .emoji-label {
+        opacity: 1;
+        font-size: 0.8em;
+      }
+    }
+
     &:hover,
     &.selected {
       .emoji-image {
         margin: -2px;
-        transition: margin $transition-speed-out;
+        transition: margin 200ms;
       }
       .emoji-label {
         top: 100%;
         font-size: 0.7em;
-        transition: top $transition-speed-out, font-size $transition-speed-out;
+        transition: top 200ms, font-size 200ms;
       }
     }
   }
@@ -34,8 +42,9 @@ $transition-speed-out: 200ms;
     right: 0;
     bottom: 0;
     display: block;
-    transition: margin $transition-speed-in;
-    margin: 0;
+    transition: margin 500ms;
+    // Completely hide the image by default by compressing it down to no space
+    margin: 50%;
   }
 
   .emoji-label {
@@ -45,7 +54,10 @@ $transition-speed-out: 200ms;
     left: 0;
     width: 100%;
     display: inline-block;
-    font-size: 0.8em;
-    transition: top $transition-speed-in, font-size $transition-speed-in;
+    transition: top 100ms, font-size 100ms, opacity 100ms;
+    // Completely hide the label by default; label & image are revealed by adding
+    // a class to the parent container element
+    opacity: 0;
+    font-size: 0;
   }
 }


### PR DESCRIPTION
This uses D3 to select the React-rendered elements, and applies a class to them with an index-staggered timeout to achieve the same effect as was accomplished earlier via JS-side transitions.

![animation](https://cloud.githubusercontent.com/assets/442115/19802830/7e81a7c8-9cd3-11e6-9fc4-063a63cdaf20.gif)

@iros I do apologize for not consulting before we migrated the rendering to D3, but here's a more minimalistic solution. I strongly prefer this approach to #30 — it is easier for me to look at the component and see what's being rendered, and how it's being modified, and doing the animation in CSS is much nicer on low-powered mobile devices. If you're concerned about being able to maintain these between my departure from the project and launch we can discuss what's best tomorrow, but I hope the approach in this PR strikes a happy medium. :)
