### PR TITLE
Whitelist PureComponets in prefer-stateless-function rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "react/jsx-filename-extension": 0,
     "react/forbid-prop-types": 0,
     "react/no-unused-prop-types": 1,
+    "react/prefer-stateless-function": ["error", { "ignorePureComponents": true }],
     "no-param-reassign": 0,
     "no-shadow": 0,
     "import/prefer-default-export": 0,

--- a/src/containers/FilterByEmojiVis.js
+++ b/src/containers/FilterByEmojiVis.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import where from '../utils/where-properties-match';
@@ -24,7 +24,7 @@ const mapStateToProps = state => ({
   selectedEmoji: getSelectedEmoji(state)
 });
 
-class FilterByEmojiVis extends Component {
+class FilterByEmojiVis extends PureComponent {
   static propTypes = {
     emoji: PropTypes.array,
     emojiQuestion: PropTypes.object,

--- a/src/containers/FilterByTopicVis.js
+++ b/src/containers/FilterByTopicVis.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import TopicBarChart from '../components/TopicBarChart';
@@ -28,7 +28,7 @@ const mapStateToProps = state => ({
   responses: getResponsesList(state)
 });
 
-class FilterByTopicVis extends Component {
+class FilterByTopicVis extends PureComponent {
   static propTypes = {
     questionsOrder: PropTypes.array,
     selectedTopic: PropTypes.object,


### PR DESCRIPTION
No lifecycle methods, no problem.

I am still confused about why only one of these was triggering a lint error.
