### PR TITLE
Only re-render letter when data is available

### DIFF
--- a/src/components/Letter.js
+++ b/src/components/Letter.js
@@ -21,6 +21,12 @@ class Letter extends PureComponent {
     this.parseEmoji();
   }
 
+  shouldComponentUpdate(nextProps) {
+    // Only re-render when a response is available; this prevents the component
+    // from emptying out when loading data (causing a flash of missing content)
+    return !!nextProps.response;
+  }
+
   componentDidUpdate() {
     this.parseEmoji();
   }

--- a/src/containers/FilterByEmojiVis.js
+++ b/src/containers/FilterByEmojiVis.js
@@ -2,10 +2,7 @@ import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import EmojiBubbleChart from '../components/EmojiBubbleChart';
-import Letter from '../components/Letter';
-
-import { emojiSVGImageTag } from '../utils/emoji';
-import DangerousInline from '../components/DangerousInline';
+import FilteredEmojiLetter from './FilteredEmojiLetter';
 
 import {
   selectEmoji,
@@ -15,86 +12,36 @@ import {
 
 import {
   getEmojiCounts,
-  getEmojiLetter,
-  getQuestionsOrder,
-  getResponsesList,
   getSelectedEmoji
 } from '../state/selectors';
 
 const mapStateToProps = state => ({
-  emoji: getEmojiCounts(state),
-  currentLetter: getEmojiLetter(state),
-  responses: getResponsesList(state),
-  questionsOrder: getQuestionsOrder(state),
+  emojiCounts: getEmojiCounts(state),
   selectedEmoji: getSelectedEmoji(state)
 });
 
 class FilterByEmojiVis extends PureComponent {
   static propTypes = {
-    emoji: PropTypes.array,
-    currentLetter: PropTypes.object,
-    questionsOrder: PropTypes.array,
-    responses: PropTypes.array,
+    emojiCounts: PropTypes.array,
     selectedEmoji: PropTypes.object,
     dispatch: PropTypes.func
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { emoji, selectedEmoji, responses } = nextProps;
-
-    // If we have no aggregations data yet, or we already have a selected emoji,
-    // skip this step entirely
-    if (!emoji || selectedEmoji) {
-      return;
-    }
-
-    // When the component has loaded but we do not yet have a selected emoji
-    // for which to show responses, start out by showing a random entry from
-    // the most recent responses
-    this.setState({
-      response: responses[Math.floor(Math.random() * responses.length)]
-    });
-  }
-
-  // Helper to page through the default responses; only used if an emoji has
-  // yet to be selected
-  showNextLetter() {
-    const { responses } = this.props;
-    const { response } = this.state;
-    const currentIdx = responses.indexOf(response);
-    const nextIdx = currentIdx + 1;
-    this.setState({
-      response: responses[nextIdx] || responses[0]
-    });
-  }
-
   render() {
     const {
-      emoji,
-      currentLetter,
-      questionsOrder,
+      emojiCounts,
       selectedEmoji,
       dispatch
     } = this.props;
 
-    if (!emoji) {
+    if (!emojiCounts) {
       return null;
-    }
-
-    const unfilteredResponse = this.state && this.state.response;
-
-    let showMoreButtonText;
-    if (selectedEmoji) {
-      const emojiImg = emojiSVGImageTag(selectedEmoji.value);
-      showMoreButtonText = (
-        <DangerousInline html={`Show another ${emojiImg} response`} />
-      );
     }
 
     return (
       <div className="filter-by-feeling">
         <EmojiBubbleChart
-          emoji={emoji}
+          emoji={emojiCounts}
           selectedEmoji={selectedEmoji}
           onSelect={(emojiId) => {
             dispatch(selectEmoji(emojiId));
@@ -104,20 +51,7 @@ class FilterByEmojiVis extends PureComponent {
           width={400}
           height={400}
         />
-        {/* Pivot between filtered & most recent responses, prioritizing filtered */}
-        {selectedEmoji ? <Letter
-          showMore={() => dispatch(showNextLetter(selectedEmoji.id))}
-          buttonText={showMoreButtonText}
-          response={currentLetter}
-          questionsOrder={questionsOrder}
-          width={400}
-        /> : <Letter
-          showMore={() => this.showNextLetter()}
-          buttonText="Show another recent response"
-          response={unfilteredResponse}
-          questionsOrder={questionsOrder}
-          width={400}
-        />}
+        <FilteredEmojiLetter />
       </div>
     );
   }

--- a/src/containers/FilteredEmojiLetter.js
+++ b/src/containers/FilteredEmojiLetter.js
@@ -1,0 +1,109 @@
+import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
+
+import Letter from '../components/Letter';
+
+import { emojiSVGImageTag } from '../utils/emoji';
+import DangerousInline from '../components/DangerousInline';
+
+import { showNextLetter } from '../state/actions';
+
+import {
+  getEmojiLetter,
+  getQuestionsOrder,
+  getResponsesList,
+  getSelectedEmoji
+} from '../state/selectors';
+
+const mapStateToProps = state => ({
+  currentLetter: getEmojiLetter(state),
+  responses: getResponsesList(state),
+  questionsOrder: getQuestionsOrder(state),
+  selectedEmoji: getSelectedEmoji(state)
+});
+
+class FilteredEmojiLetter extends Component {
+  static propTypes = {
+    currentLetter: PropTypes.object,
+    questionsOrder: PropTypes.array,
+    responses: PropTypes.array,
+    selectedEmoji: PropTypes.object,
+    dispatch: PropTypes.func
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { selectedEmoji, responses } = nextProps;
+
+    // If we don't have response data yet, or already have a selected emoji,
+    // skip this step entirely
+    if (!responses.length || selectedEmoji) {
+      return;
+    }
+
+    // When the component has loaded but we do not yet have a selected emoji
+    // for which to show responses, start out by showing a random entry from
+    // the most recent responses
+    this.setState({
+      response: responses[Math.floor(Math.random() * responses.length)]
+    });
+  }
+
+  // Helper to page through the default responses; only used if an emoji has
+  // yet to be selected
+  showNextLetter() {
+    const { responses } = this.props;
+    const { response } = this.state;
+    const currentIdx = responses.indexOf(response);
+    const nextIdx = currentIdx + 1;
+    this.setState({
+      response: responses[nextIdx] || responses[0]
+    });
+  }
+
+  render() {
+    const {
+      currentLetter,
+      questionsOrder,
+      selectedEmoji,
+      dispatch
+    } = this.props;
+
+    const unfilteredResponse = this.state && this.state.response;
+
+    if (!currentLetter && !unfilteredResponse) {
+      return null;
+    }
+
+    let showMoreButtonText;
+    if (selectedEmoji) {
+      const emojiImg = emojiSVGImageTag(selectedEmoji.value);
+      showMoreButtonText = (
+        <DangerousInline html={`Show another ${emojiImg} response`} />
+      );
+    }
+
+    // Pivot between filtered & most recent responses
+    if (selectedEmoji) {
+      // If we have an emoji filter, show those letters
+      return (
+        <Letter
+          showMore={() => dispatch(showNextLetter(selectedEmoji.id))}
+          buttonText={showMoreButtonText}
+          response={currentLetter}
+          questionsOrder={questionsOrder}
+        />
+      );
+    }
+    // Otherwise, show most recent responses
+    return (
+      <Letter
+        showMore={() => this.showNextLetter()}
+        buttonText="Show another recent response"
+        response={unfilteredResponse}
+        questionsOrder={questionsOrder}
+      />
+    );
+  }
+}
+
+export default connect(mapStateToProps)(FilteredEmojiLetter);


### PR DESCRIPTION
This fixes a flash of missing content when downloading new response data; this is particularly beneficial for mobile devices, where this will result in less content positioning jump that could cause a user to mis-tap.