### PR TITLE
Fix issue with pop-out animation and bad scaling on devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-dev-server": "1.16.1"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "d3-array": "^1.0.1",
     "d3-axis": "^1.0.3",
     "d3-collection": "^1.0.1",

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -1,4 +1,4 @@
-$emoji-pop-in-transition-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
+$emoji-pop-in-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
 
 .filter-by-feeling {
   border-bottom: 6px solid white;
@@ -10,14 +10,14 @@ $emoji-pop-in-transition-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
 }
 
 .emojis-group-container {
-  position: relative;
   margin-bottom: 20px;
+  position: relative;
+  width: 100%;
 
   .emoji-container {
     position: absolute;
     cursor: pointer;
     text-align: center;
-    transition: width 200ms, height 200ms;
 
     &::-moz-focus-inner {
       border: 0;
@@ -28,59 +28,66 @@ $emoji-pop-in-transition-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
       border: 0;
     }
 
-    > img {
-      max-width: 90%;
-    }
-
-    &.visible {
-      .emoji-image {
-        margin: 0;
-      }
-      .emoji-label {
-        opacity: 1;
-        font-size: 0.8em;
-      }
-    }
-
     &:hover,
     &.selected {
       .emoji-image {
-        margin: -3px;
-        transition: margin 200ms;
+        width: 100%;
+        // Speed at which the element animates into selected state
+        transition: max-width 100ms;
+        margin-bottom: -3%;
       }
       .emoji-label {
         top: 100%;
         font-size: 0.7em;
-        transition: top 200ms, font-size 200ms;
+        // Speed at which the element animates into selected state
+        transition: top 100ms, font-size 100ms;
       }
     }
   }
 
   .emoji-image {
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
     display: block;
-    transition: margin 550ms $emoji-pop-in-transition-timing;
-    transition-timing-function: $emoji-pop-in-transition-timing;
-    // Completely hide the image by default by compressing it down to no space
-    margin: 50%;
+    margin: 0 auto;
+    max-width: 96%;
+    // speed at which the element returns to normal
+    transition: max-width 200ms;
   }
 
   .emoji-label {
-    position: absolute;
-    margin: auto;
-    top: 98%;
-    left: 0;
+    // position: absolute;
+    margin: 0 auto;
+    // top: 98%;
+    // left: 0;
     width: 100%;
     display: inline-block;
-    transition: top 200ms, font-size 200ms, opacity 200ms;
-    // Completely hide the label by default; label & image are revealed by adding
-    // a class to the parent container element
-    opacity: 0;
-    font-size: 0;
+    // speed at which the element returns to normal
+    transition: font-size 200ms, opacity 200ms;
+    opacity: 1;
+    font-size: 0.8em;
+  }
+
+  .hidden {
+    .emoji-image {
+      // Completely hide the image by default by compressing it down to no space
+      max-width: 1px;
+    }
+    .emoji-label {
+      // Completely hide the label by default; label & image are revealed by adding
+      // a class to the parent container element
+      opacity: 0;
+      font-size: 0;
+    }
+  }
+
+  .pop-in {
+    .emoji-image {
+      transition: max-width 550ms $emoji-pop-in-timing;
+      transition-timing-function: $emoji-pop-in-timing;
+    }
+    .emoji-label {
+      transition: font-size 550ms $emoji-pop-in-timing, opacity 550ms $emoji-pop-in-timing;
+      transition-timing-function: $emoji-pop-in-timing;
+    }
   }
 }
 


### PR DESCRIPTION
Remaining issues:

The span tags overlap the other images; I can scale down the emoji to make them fit in the circle, but I'm investigating z-index and other tricks to ensure that the emoji themselves are the forefront clickable element.
![image](https://cloud.githubusercontent.com/assets/442115/19907395/08bdff16-a055-11e6-8cc9-44381a7a9b24.png)

Percentage label alignment is way off in IE, exacerbating the above problem:
![image](https://cloud.githubusercontent.com/assets/442115/19907498/7e4bf10c-a055-11e6-8159-5d498d7e38a9.png)

