### PR TITLE
Fix remaining Emoji bubble chart layout & animation issues

### DIFF
--- a/src/components/EmojiBubbleChart.js
+++ b/src/components/EmojiBubbleChart.js
@@ -143,6 +143,8 @@ export default class EmojiBubbleChart extends PureComponent {
             const isSelected = selectedEmoji && (id === selectedEmoji.id);
             const key = `bubble${id}`;
 
+            // See EmojiBubbleChart.scss for a thorough explanation of the
+            // purposes for each of these classes
             const classes = classNames('emoji-container', {
               selected: isSelected,
               // Give newly-rendered items the "hidden" and "pop-in" classes

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -1,4 +1,32 @@
-$emoji-pop-in-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
+/*
+Most of the CSS in this file is related to the staggered pop-in transition
+we use to reveal the emoji.
+
+The DOM structure is this:
+
+  div.emojis-group-container
+    button.emoji-container
+      span.emoji-image
+        img src="emoji.svg"
+      span.emoji-label
+
+When rendered, .emoji-container elements are .pop-in.hidden; these classes
+are removed by d3 in componentDidUpdate following the first render. The .hidden
+class applies the CSS rules to make the emoji start out invisibly small; the
+.pop-in class adds the longer, more cartoony CSS transition timing needed for
+the pop-in effect to look its best.
+
+Removing the .hidden class allows the default sizing rules to apply, causing
+the emoji to zoom in and the text to fade in below. Once the initial transition
+is complete for all elements the .pop-in class is also removed, so that the
+more-boring-but-more-predictable default CSS transition timing is in play for
+hover-over effects.
+
+Absolute positioning is used to mitigate cross-browser inconsistencies that we
+encountered with margins, and so that the "hit box" of the percentage labels can
+be shrunk laterally & z-indexed behind other emoji to prevent mis-click errors.
+*/
+$emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
 
 .filter-by-feeling {
   border-bottom: 6px solid white;
@@ -31,9 +59,11 @@ $emoji-pop-in-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
     &:hover,
     &.selected {
       .emoji-image {
-        width: 100%;
-        // Speed at which the element animates into selected state
-        transition: max-width 100ms;
+        img {
+          max-width: 100%;
+          // Speed at which the element animates into selected state
+          transition: max-width 100ms;
+        }
         margin-bottom: -3%;
       }
       .emoji-label {
@@ -43,50 +73,66 @@ $emoji-pop-in-timing: cubic-bezier(0.960, -0.115, 0.480, 1.625);
         transition: top 100ms, font-size 100ms;
       }
     }
+    &.selected {
+      .emoji-label {
+        font-weight: bold;
+      }
+    }
   }
 
   .emoji-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
     display: block;
     margin: 0 auto;
-    max-width: 96%;
-    // speed at which the element returns to normal
-    transition: max-width 200ms;
+    z-index: 10;
+    img {
+      max-width: 96%;
+      // speed at which the element returns to normal
+      transition: max-width 200ms;
+    }
   }
 
   .emoji-label {
-    // position: absolute;
-    margin: 0 auto;
-    // top: 98%;
-    // left: 0;
-    width: 100%;
-    display: inline-block;
-    // speed at which the element returns to normal
-    transition: font-size 200ms, opacity 200ms;
+    position: absolute;
+    display: block;
+    top: 96%;
+    left: 50%;
+    width: 3em;
+    margin-left: -1.5em;
     opacity: 1;
+    z-index: 0;
     font-size: 0.8em;
+    // speed at which the element returns to normal
+    transition: opacity 200ms, font-size 100ms;
   }
 
   .hidden {
     .emoji-image {
-      // Completely hide the image by default by compressing it down to no space
-      max-width: 1px;
+      img {
+        // Completely hide the image by default by compressing it down to no space
+        max-width: 1px;
+      }
     }
     .emoji-label {
       // Completely hide the label by default; label & image are revealed by adding
       // a class to the parent container element
       opacity: 0;
-      font-size: 0;
     }
   }
 
   .pop-in {
     .emoji-image {
-      transition: max-width 550ms $emoji-pop-in-timing;
-      transition-timing-function: $emoji-pop-in-timing;
+      img {
+        transition: max-width 550ms $emoji-pop-in-timing;
+        transition-timing-function: $emoji-pop-in-timing;
+      }
     }
     .emoji-label {
-      transition: font-size 550ms $emoji-pop-in-timing, opacity 550ms $emoji-pop-in-timing;
-      transition-timing-function: $emoji-pop-in-timing;
+      transition: opacity 200ms 350ms;
     }
   }
 }


### PR DESCRIPTION
Internet Explorer was exhibiting interaction-blocking layout bugs, and the other browsers could have used some polish; this PR finishes that polishing. A more thorough explanation of what's going on in the CSS is also provided as a comment in the sidecar SASS file, for future clarity and debugging assistance.

Fixes #72

Internet Explorer screen capture:

![ie emoji pop-in fixed](https://cloud.githubusercontent.com/assets/442115/19929357/56bcc13c-a0d9-11e6-9b16-3fbae58a8ae3.gif)