### PR TITLE
Sort topic bar chart by count so most common response is first

### DIFF
--- a/src/state/__tests__/reducer.responses.test.js
+++ b/src/state/__tests__/reducer.responses.test.js
@@ -52,6 +52,7 @@ describe('responses reducer', () => {
               group_by: false
             }
           },
+          aggregations: {},
           submissions: [
             { id: '01234', sentiment: 'meh' },
             { id: '56789', sentiment: 'woo' },

--- a/src/state/__tests__/selectors.test.js
+++ b/src/state/__tests__/selectors.test.js
@@ -547,12 +547,12 @@ describe('get____Counts', () => {
       expect(getTopicCounts(defaultState)).toEqual([]);
     });
 
-    it('returns a dictionary by question ID of topic object lists, with counts', () => {
+    it('returns a sorted array of topic object lists, with counts', () => {
       const result = getTopicCounts(populatedState);
       expect(result).toEqual([
-        { id: 'econ', value: 'Economy', count: 3 },
+        { id: 'env', value: 'Environment', count: 12 },
         { id: 'edu', value: 'Education', count: 4 },
-        { id: 'env', value: 'Environment', count: 12 }
+        { id: 'econ', value: 'Economy', count: 3 }
       ]);
     });
 

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -128,9 +128,11 @@ export const getEmojiCounts = createSelector(
 export const getTopicCounts = createSelector(
   getTopicList,
   getAggregations,
-  (topicList, aggregations) => topicList.map(option => Object.assign({
-    count: aggregations[option.id].count
-  }, option))
+  (topicList, aggregations) => topicList
+    .map(option => Object.assign({
+      count: aggregations[option.id].count
+    }, option))
+    .sort((a, b) => b.count - a.count)
 );
 
 /**


### PR DESCRIPTION
Fixes #66:

> Request from The Washington Post graphics team:
>
> On the Filter by Topic section, Please order the topics by percentage of responses, with the top vote-getter at the top of the list and the lowest vote-getter at the bottom of the list.

![image](https://cloud.githubusercontent.com/assets/442115/19929631/9d961ddc-a0da-11e6-9482-97fd280bc303.png)