### PR TITLE
Reinstate, but make subtle, keyboard selection indicators

### DIFF
--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -69,7 +69,7 @@ p {
 .emoji-container.selected.visible {
   background: #e6e6e6;
   border-radius: 5px;
-  
+
   .emoji-image {
     padding: .2em;
   }
@@ -127,5 +127,7 @@ button {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  outline: none !important;
+  &:active {
+    outline: 0;
+  }
 }

--- a/src/components/EmojiBarChart.js
+++ b/src/components/EmojiBarChart.js
@@ -64,11 +64,12 @@ class EmojiBarChart extends PureComponent {
       .domain(d3.extent(emoji, d => d.count))
       .range([0, maxBarHeight]);
 
-    const binding = parent.selectAll('div.emoji-bar-container')
+    const binding = parent.selectAll('button.emoji-bar-container')
       .data(emoji, d => `${d.id}-${d.count}`);
 
     const entering = binding.enter()
-      .append('div')
+      .append('button')
+      .attr('type', 'button')
       .classed('emoji-bar-container', true);
 
     // Each emoji bar container has:
@@ -104,10 +105,14 @@ class EmojiBarChart extends PureComponent {
     // Click handlers
     mergedSelection
       .classed('enabled', d => !!d.count)
+      .attr('disabled', d => (d.count ? null : 1))
       .on('click', (d) => {
         if (d.count) {
           onSelect(d.id);
         }
+        mergedSelection.classed('selected', d1 => (
+          !!d.count && d1.id === d.id
+        ));
       });
 
     // 1. animate bars

--- a/src/components/EmojiBarChart.scss
+++ b/src/components/EmojiBarChart.scss
@@ -15,9 +15,19 @@
     .emoji-bar-container {
       display: inline-block;
       width: 20%;
+      outline-width: 0;
 
       &.enabled {
         cursor: pointer;
+
+        // Keyboard nav
+        outline-width: 1px;
+        outline-color: rgba(153,153,153,0.1);
+        outline-offset: -1px;
+
+        &.selected {
+          outline: 0;
+        }
       }
 
       .bar {

--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -51,12 +51,18 @@ $emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
       border: 0;
     }
 
-    &:focus, &:active {
-      outline: 0;
+    &:active {
       border: 0;
+      outline: 0;
+    }
+    &:focus {
+      border: 0;
+      outline-width: 1px;
+      outline-color: rgba(153,153,153,0.1);
     }
 
     &:hover,
+    &:focus,
     &.selected {
       .emoji-image {
         img {
@@ -74,6 +80,7 @@ $emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
       }
     }
     &.selected {
+      outline: 0;
       .emoji-label {
         font-weight: bold;
       }

--- a/src/components/TopicBarChart.js
+++ b/src/components/TopicBarChart.js
@@ -1,4 +1,5 @@
 import React, { PureComponent, PropTypes } from 'react';
+import classNames from 'classnames';
 import d3 from '../d3';
 import GoogleSheetFieldComponent from '../containers/GoogleSheetFieldComponent';
 
@@ -45,12 +46,16 @@ class TopicBarChart extends PureComponent {
             const percentage = topic.count ?
               d3.format('.0%')(topic.count / responseCount) :
               0;
+            const isSelected = selectedTopic && (topic.id === selectedTopic.id);
+            const classes = classNames('bar-group', {
+              selected: isSelected
+            });
             return (
               <button
-                aria-pressed={selectedTopic && (topic.id === selectedTopic.id)}
+                aria-pressed={isSelected}
                 onClick={() => onSelect(topic.id)}
                 key={topic.value}
-                className="bar-group"
+                className={classes}
               >
                 <div className="topic-detail-container">
                   <div className="topic-name">{topic.value}</div>

--- a/src/components/TopicBarChart.scss
+++ b/src/components/TopicBarChart.scss
@@ -49,27 +49,28 @@
     transition: width 200ms;
   }
 
-  .bar-group:hover {
+  .bar-group {
+    &.selected,
+    &:focus,
+    &:hover {
+      outline-width: 1px;
+      outline-color: rgba(153,153,153,0.1);
 
-    .topic-bar {
-      background-color: $highlight;
+      .topic-bar {
+        background-color: $highlight;
+      }
+    }
+    &.selected {
+      outline: 0;
     }
   }
 }
 
-  @media only screen and (min-width: 47em) { 
-    // .bar-group {
-    //   width: 48%;
-    // }
-
-    // .bar-group:nth-child(odd) {
-    //   float: right;
-    // }
-
-    .topic-bar-chart {
-      width: 50%;
-      float: left;
-      padding-right: 3em;
-    }
+@media only screen and (min-width: 47em) {
+  .topic-bar-chart {
+    width: 50%;
+    float: left;
+    padding-right: 3em;
   }
+}
 


### PR DESCRIPTION
Changes in some of the styling patches negatively impacted the keyboard
usability of the visualization.

![keyboard-accessibility](https://cloud.githubusercontent.com/assets/442115/19930890/d1fae73c-a0e0-11e6-9dea-f24362e0967f.gif)