### PR TITLE
Don’t allow label to trigger hover over.

### DIFF
--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -104,6 +104,7 @@ $emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
   }
 
   .emoji-label {
+    pointer-events: none;
     position: absolute;
     display: block;
     top: 96%;


### PR DESCRIPTION
![hover](https://cloud.githubusercontent.com/assets/9369/19940117/cf661200-a0e8-11e6-9111-d1cd5eedf63c.gif)

label hover makes a weird double expand effect. this removes that effect. 