### PR TITLE
Add a radial gradient bg behind the selected emoji

### DIFF
--- a/src/components/EmojiBubbleChart.scss
+++ b/src/components/EmojiBubbleChart.scss
@@ -75,6 +75,8 @@ $emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
 
     &.selected {
       outline: 0;
+      background: radial-gradient(#666 0%, rgba(0, 0, 0, 0) 70%);
+
       .emoji-label {
         font-weight: bold;
       }
@@ -82,6 +84,7 @@ $emoji-pop-in-timing: cubic-bezier(.75,.05,.33,1.38);
   }
 
   .emoji-image {
+    transform: scale(0.92);
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Attempt to make the selected emoji more visible by using a radial gradient. Resolves #114 

![coral_gradient_highlight](https://cloud.githubusercontent.com/assets/793847/19945682/924cd1d6-a117-11e6-9278-bc0fc7248f97.gif)
