### PR TITLE
Add pym support

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash.intersection": "^4.4.0",
     "lodash.uniq": "^4.5.0",
+    "pym.js": "^1.1.1",
     "react": "^15.3.2",
     "react-computed-props": "^0.1.1",
     "react-dom": "^15.3.2",

--- a/src/components/EmbeddedAskForm.js
+++ b/src/components/EmbeddedAskForm.js
@@ -13,7 +13,9 @@ import d3 from '../d3';
  */
 export default class EmbeddedAskForm extends Component {
   static propTypes = {
-    formScript: PropTypes.string
+    formScript: PropTypes.string,
+    formVisible: PropTypes.bool,
+    onChangeFormVisibility: PropTypes.func
   }
 
   constructor(props) {
@@ -21,7 +23,6 @@ export default class EmbeddedAskForm extends Component {
 
     // start with the form closed.
     this.state = {
-      open: false,
       scriptInjected: false,
       submitted: false
     };
@@ -116,20 +117,22 @@ export default class EmbeddedAskForm extends Component {
    * Callback to handle toggling the form open or close by setting state
    */
   toggleForm() {
-    this.setState({ open: !this.state.open });
+    this.props.onChangeFormVisibility(!this.props.formVisible);
   }
 
   /**
    * Get the button text based on the state of the form
    */
   renderToggleButton() {
-    const { open, submitted } = this.state;
+    const { formVisible } = this.props;
+    const { submitted } = this.state;
+
     let fieldId;
     let defaultValue;
 
     // show the button only if the form hasn't been submitted yet.
     if (!submitted) {
-      if (open) {
+      if (formVisible) {
         fieldId = 'elc-text-button-close-form';
         defaultValue = 'Don\'t submit, close form';
       } else {
@@ -157,13 +160,13 @@ export default class EmbeddedAskForm extends Component {
    * Main render function that draws the form
    */
   render() {
-    const { open } = this.state;
+    const { formVisible } = this.props;
 
     // form should be loaded closed.
     // after the script tag has come in, make sure the ask-form has the right
     return (
       <div
-        className={classNames('form-container', { open })}
+        className={classNames('form-container', { open: formVisible })}
         ref={(node) => { this.formContainer = node; }}
       >
         <div id="ask-form"className="embedded-form" />

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -10,15 +10,28 @@ import getConfig from '../config';
 
 // import ShortAnswerList from '../components/ShortAnswerList';
 
-import { fetchFormDigestIfNeeded } from '../state/actions';
+import { fetchFormDigestIfNeeded, showForm, hideForm } from '../state/actions';
 
 // Assign value once config loads
 let formScript;
 getConfig.then(config => (formScript = config.formScript));
 
+function mapStateToProps(state) {
+  return {
+    formVisible: state.form.formVisible
+  };
+}
+
 class App extends Component {
   static propTypes = {
-    dispatch: PropTypes.func
+    dispatch: PropTypes.func,
+    formVisible: PropTypes.bool
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.handleFormVisibilityChange = this.handleFormVisibilityChange.bind(this);
   }
 
   componentWillMount() {
@@ -26,11 +39,26 @@ class App extends Component {
     dispatch(fetchFormDigestIfNeeded());
   }
 
+  handleFormVisibilityChange(visible) {
+    const { dispatch } = this.props;
+    if (visible) {
+      dispatch(showForm());
+    } else {
+      dispatch(hideForm());
+    }
+  }
+
   render() {
+    const { formVisible } = this.props;
+
     return (
       <div className="App" ref={(node) => { this.root = node; }}>
 
-        <EmbeddedAskForm formScript={formScript} />
+        <EmbeddedAskForm
+          formVisible={formVisible}
+          onChangeFormVisibility={this.handleFormVisibilityChange}
+          formScript={formScript}
+        />
 
         <div className="container">
           <FilterByEmojiVis />
@@ -45,4 +73,4 @@ class App extends Component {
 }
 
 // Use connect() with no argument to get props.dispatch()
-export default connect()(App);
+export default connect(mapStateToProps)(App);

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -3,6 +3,13 @@ import * as api from '../api/api';
 import { combineIds } from '../utils/id-list';
 
 /**
+ * Action creators for toggling the form visibility
+ */
+export const showForm = createAction('SHOW_FORM');
+export const hideForm = createAction('HIDE_FORM');
+
+
+/**
  * Action creators for requesting and receiving data. Identity used for payload
  */
 export const requestFormDigest = createAction('REQUEST_FORM_DIGEST');

--- a/src/state/pymMiddleware.js
+++ b/src/state/pymMiddleware.js
@@ -1,0 +1,13 @@
+import pym from 'pym.js';
+
+const pymChild = new pym.Child();
+
+/**
+ * Update pym each time an action is fired.
+ */
+const pymMiddleware = () => next => (action) => {
+  pymChild.sendHeight();
+  return next(action);
+};
+
+export default pymMiddleware;

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -266,7 +266,20 @@ export const responses = handleActions({
   isFetching: null
 });
 
+export const form = handleActions({
+  SHOW_FORM: () => ({
+    formVisible: true
+  }),
+
+  HIDE_FORM: () => ({
+    formVisible: false
+  })
+}, {
+  formVisible: false
+});
+
 export default combineReducers({
+  form,
   summary,
   fields,
   selected,

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -2,6 +2,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 import rootReducer from './reducer';
+import pymMiddleware from './pymMiddleware';
 
 const loggerMiddleware = createLogger({
   collapsed: true,
@@ -10,7 +11,7 @@ const loggerMiddleware = createLogger({
 
 // define which middleware to use depending on environment
 let composeEnhancers = compose;
-const middleware = [thunkMiddleware];
+const middleware = [thunkMiddleware, pymMiddleware];
 
 // when not in production enable redux tools and add logger middleware
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
Makes the site use pym as a child. On every redux action that is fired, it updates pym.

Pym: http://blog.apps.npr.org/pym.js/

Also updates the embedded form to store the visibility of the form in redux so that we use an action (and thus it gets picked up by pym)