### PR TITLE
Delay until next tick to update pym so it gets re-rendered content

### DIFF
--- a/src/state/pymMiddleware.js
+++ b/src/state/pymMiddleware.js
@@ -6,7 +6,11 @@ const pymChild = new pym.Child();
  * Update pym each time an action is fired.
  */
 const pymMiddleware = () => next => (action) => {
-  pymChild.sendHeight();
+  // delay until next tick to let react re-render
+  setTimeout(() => {
+    pymChild.sendHeight();
+  }, 0);
+
   return next(action);
 };
 


### PR DESCRIPTION
The problem with pym updating before is that it was firing the update as the action was received, but it needs to happen after react has re-rendered, so I use `setTimeout(..., 0)` to do it.