### PR TITLE
Re-twemojify selection on blur of inputs in the form

### DIFF
--- a/src/components/EmbeddedAskForm.js
+++ b/src/components/EmbeddedAskForm.js
@@ -1,9 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
-import twemoji from 'twemoji';
 
 import GoogleSheetFieldComponent from '../containers/GoogleSheetFieldComponent';
-import { emojiSVGUrl } from '../utils/emoji';
+import { twemojifySelection } from '../utils/emoji';
 import './EmbeddedAskForm.scss';
 import d3 from '../d3';
 
@@ -95,21 +94,24 @@ export default class EmbeddedAskForm extends Component {
    * Should be run after the form has been rendered.
    */
   addRerenderTwemojiFix() {
+    const root = d3.select(this.formContainer);
     // bind events to labels
-    const allLabels = d3.select(this.formContainer)
-      .selectAll('label');
+    const allLabels = root.selectAll('label');
 
     // re-emojify all nodes
-    allLabels.nodes().forEach((node) => {
-      twemoji.parse(node, icon => emojiSVGUrl(icon));
-    });
+    twemojifySelection(allLabels);
 
     // also re-emojify on click
     allLabels.on('click', () => {
       // re-emojify all nodes
-      allLabels.nodes().forEach((node) => {
-        twemoji.parse(node, icon => emojiSVGUrl(icon));
-      });
+      twemojifySelection(allLabels);
+    });
+
+    // listen for blur on inputs since this causes a re-render of
+    // the ask form. See https://github.com/bocoup/coral-ask-election-2016/issues/123
+    root.selectAll('input').on('blur', () => {
+      // re-emojify all nodes
+      twemojifySelection(allLabels);
     });
   }
 

--- a/src/utils/emoji.js
+++ b/src/utils/emoji.js
@@ -43,3 +43,15 @@ export const blockEmoji = (emojiUnicode, props) => {
   }, props));
   /* eslint-enable new-cap */
 };
+
+
+/**
+ * twemojifies selected nodes (typically used on answers in the ask form)
+ * Takes a d3 selection (d3.selectAll() output)
+ * @return {void}
+ */
+export function twemojifySelection(selection) {
+  selection.nodes().forEach((node) => {
+    twemoji.parse(node, icon => emojiSVGUrl(icon));
+  });
+}


### PR DESCRIPTION
Resolves #123 by listening for blur events on inputs and re-rendering twemojies.

![coral-emoji-fix](https://cloud.githubusercontent.com/assets/793847/19968762/4ed8e0d0-a1ac-11e6-9ade-a1e7e318db21.gif)
