### PR TITLE
Import more-generic styles first so they render with lower priority

### DIFF
--- a/scripts/generate-css-override.js
+++ b/scripts/generate-css-override.js
@@ -95,15 +95,15 @@ const whitelist = ast => {
  * @returns {String} The cleaned stylesheet string
  */
 const beautify = cssStr => cssStr
+  // Strip line comments, including sourcemap comment
+  .replace(/\/\*[^\n]+\*\/(\n|$)/g, '')
   // Remove empty media blocks
   .replace(/\n@media[^{]+\{\s+\}/g, '')
   // Strip superfluous newlines
   .replace(/\{\n{2,}/g, '{\n')
   .replace(/^\n+/, '')
   .replace(/\n{2,}/g, '\n\n')
-  .replace(/\n+$/, '')
-  // Strip no-longer-accurate sourcemap comment
-  .replace(/\n+\/\*[^\n]+$/, '')
+  .replace(/\n+$/, '');
 
 /**
  * Write out the overrides CSS file to the build directory

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import { Provider } from 'react-redux';
 
-import App from './App';
 import '../assets/base.scss';
+import App from './App';
 
 const Root = ({ store }) => (
   <Provider store={store}>


### PR DESCRIPTION
This fixes #126 by importing the base styles before the app components, so that in the generated CSS generic selectors like `h1` and `.btn` will occur before (and therefore be overridden by) specific selectors like `.form-toggle-button`.

@pbeshai Please review, and especially let me know if you see any changes introduced by flipping this ordering