### PR TITLE
Adjust formatting of default Letter response text

### DIFF
--- a/src/components/Letter.js
+++ b/src/components/Letter.js
@@ -48,18 +48,14 @@ class Letter extends PureComponent {
                 Dear [Secretary Clinton/Mr. Trump],
               </p>
               <p>
-                As you prepare to become president I am feeling <span className='emoji'>
-                  ${responseField(0)}
-                </span>.
-                I think your top priority should be <span className='achieve'>
-                  {responseField(1)}
-                </span>.
+                As you prepare to become president I am feeling
+                <span className='emoji'>${responseField(0)}</span>.
+                I think your top priority should be
+                <span className='achieve'>${responseField(1)}</span>.
               </p>
               <p>
-                If you achieve one thing in the next four years, I want it to
-                be: <span className='achieve'>
-                  ${responseField(2)}
-                </span>.
+                If you achieve one thing in the next four years, I want it to be:
+                <span className='achieve'>${responseField(2)}</span>
               </p>
               <p>
                 Thank you and good luck. <br /> ${responseField(3)}, ${responseField(4)}


### PR DESCRIPTION
This does a few things:

- Changes `{responseField(1)}` to `${responseField(1)}` to make that field correctly render on Windows Phone devices (it's odd that this was working at all on other devices given the malformed template string).
- Change line break placement of emoji and key-topic tokens so that the sentence-terminating period is not separated from the user's response by a space
- Remove the period at the end of the free-response field's output because many of our initial sample survey respondents finished their submission with an exclamation or other punctuation, and displaying "!." was not appealing

Screenshot:

![image](https://cloud.githubusercontent.com/assets/442115/19982580/00421cbc-a1dd-11e6-8a87-b743682d79d1.png)