### PR TITLE
Disable "next letter" button when only one response available

### DIFF
--- a/src/components/Letter.scss
+++ b/src/components/Letter.scss
@@ -1,3 +1,5 @@
+@import '../shared/shared.scss';
+
 .letter {
 
   .letter-content {
@@ -25,9 +27,14 @@
     background: #D9D9D9;
     color: #616161;
     display: block;
+
+    &:disabled {
+      background: $lightgrey;
+      color: $medgrey;
+    }
   }
 
-  .btn:hover {
+  .btn:not(:disabled):hover {
     background: #cccccc;
   }
 

--- a/src/containers/FilterByTopicVis.js
+++ b/src/containers/FilterByTopicVis.js
@@ -21,6 +21,7 @@ import {
   getQuestionsOrder,
   getSelectedTopic,
   getTopicLetter,
+  getTopicLetterCount,
   getSelectedTopicEmoji,
   getTopicCounts
 } from '../state/selectors';
@@ -31,6 +32,7 @@ const mapStateToProps = state => ({
   selectedTopicEmoji: getSelectedTopicEmoji(state),
   topicLetter: getTopicLetter(state),
   topics: getTopicCounts(state),
+  filteredLetterCount: getTopicLetterCount(state),
   filteredEmojiCounts: getEmojiCountsFilteredByTopic(state)
 });
 
@@ -41,6 +43,7 @@ class FilterByTopicVis extends PureComponent {
     selectedTopicEmoji: PropTypes.object,
     topics: PropTypes.array,
     topicLetter: PropTypes.object,
+    filteredLetterCount: PropTypes.number,
     filteredEmojiCounts: PropTypes.array,
     dispatch: PropTypes.func
   }
@@ -92,6 +95,7 @@ class FilterByTopicVis extends PureComponent {
       questionsOrder,
       topics,
       topicLetter,
+      filteredLetterCount,
       selectedTopic,
       selectedTopicEmoji,
       filteredEmojiCounts
@@ -130,6 +134,7 @@ class FilterByTopicVis extends PureComponent {
         <Letter
           showMore={() => this.showNextLetter()}
           buttonText={showMoreButtonText}
+          buttonDisabled={filteredLetterCount <= 1}
           response={topicLetter}
           questionsOrder={questionsOrder}
           width={400}

--- a/src/containers/FilteredEmojiLetter.js
+++ b/src/containers/FilteredEmojiLetter.js
@@ -10,6 +10,7 @@ import { showNextLetter } from '../state/actions';
 
 import {
   getEmojiLetter,
+  getEmojiLetterCount,
   getQuestionsOrder,
   getResponsesList,
   getSelectedEmoji
@@ -18,6 +19,7 @@ import {
 const mapStateToProps = state => ({
   currentLetter: getEmojiLetter(state),
   responses: getResponsesList(state),
+  filteredLetterCount: getEmojiLetterCount(state),
   questionsOrder: getQuestionsOrder(state),
   selectedEmoji: getSelectedEmoji(state)
 });
@@ -27,6 +29,7 @@ class FilteredEmojiLetter extends Component {
     currentLetter: PropTypes.object,
     questionsOrder: PropTypes.array,
     responses: PropTypes.array,
+    filteredLetterCount: PropTypes.number,
     selectedEmoji: PropTypes.object,
     dispatch: PropTypes.func
   }
@@ -63,8 +66,10 @@ class FilteredEmojiLetter extends Component {
   render() {
     const {
       currentLetter,
+      filteredLetterCount,
       questionsOrder,
       selectedEmoji,
+      responses,
       dispatch
     } = this.props;
 
@@ -89,6 +94,7 @@ class FilteredEmojiLetter extends Component {
         <Letter
           showMore={() => dispatch(showNextLetter(selectedEmoji.id))}
           buttonText={showMoreButtonText}
+          buttonDisabled={filteredLetterCount <= 1}
           response={currentLetter}
           questionsOrder={questionsOrder}
         />
@@ -99,6 +105,7 @@ class FilteredEmojiLetter extends Component {
       <Letter
         showMore={() => this.showNextLetter()}
         buttonText="Show another recent response"
+        buttonDisabled={responses.length <= 1}
         response={unfilteredResponse}
         questionsOrder={questionsOrder}
       />

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -267,8 +267,9 @@ export const getTopicLetter = createSelector(
  */
 export const getTopicLetterCount = createSelector(
   getAggregations,
+  getFilterQuestions,
   getSelected,
-  (aggregations, selected) => {
+  (aggregations, filterQuestions, selected) => {
     const topicId = selected.topic;
     const emojiId = selected.topicEmoji;
     if (!topicId || !aggregations[topicId]) {
@@ -277,6 +278,10 @@ export const getTopicLetterCount = createSelector(
     if (!emojiId) {
       return aggregations[topicId].count || 0;
     }
-    return aggregations[topicId][emojiId] ? aggregations[topicId][emojiId].count : 0;
+    return safeDeepAccess(aggregations, [
+      topicId,
+      filterQuestions.emoji,
+      emojiId
+    ]) || 0;
   }
 );

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -22,7 +22,6 @@ export const getContentFields = state => state.fields.data;
  * This selector can be used to display a global fetching-state indicator,
  * such as an activity spinner.
  *
- * @param {Object} state The state
  * @returns {Boolean} Whether any AJAX request is in progress.
  */
 export const getIsFetching = state => [
@@ -31,26 +30,48 @@ export const getIsFetching = state => [
   'fields'
 ].reduce((isFetching, storeKey) => isFetching || state[storeKey].isFetching, false);
 
+/**
+ * Get the list of question objects, ordered as they occur within the Ask form
+ *
+ * @returns {Object[]} Array of question objects
+ */
 export const getQuestionsList = createSelector(
   getQuestions,
   getQuestionsOrder,
   (questions, order) => order.map(id => questions[id])
 );
 
+/**
+ * Get the available question responses as an ordered array of question objects
+ * (ordered by the order in which the user clicks on answer filters, then recency)
+ *
+ * @returns {Object[]} Array of question objects
+ */
 export const getResponsesList = createSelector(
   getResponses,
   getResponseOrder,
   (responses, order) => order.map(id => responses[id])
 );
 
+// Parse out the content fields from the content fields data store
 export const getContentFieldsData = createSelector(getContentFields, listToObject('field-id (don\'t change!)'));
 
+/**
+ * Get the question object representing the emoji filter question
+ *
+ * @returns {Object} The question object for the emoji question
+ */
 export const getEmojiQuestion = createSelector(
   getQuestions,
   getFilterQuestions,
   (questions, filterQuestions) => questions && questions[filterQuestions.emoji]
 );
 
+/**
+ * Get the question object representing the topic filter question
+ *
+ * @returns {Object} The question object for the topic question
+ */
 export const getTopicQuestion = createSelector(
   getQuestions,
   getFilterQuestions,
@@ -81,18 +102,34 @@ export const getTopicList = createSelector(
   topicQuestion => (topicQuestion && topicQuestion.options) || []
 );
 
+/**
+ * Get the currently selected emoji answer object
+ *
+ * @returns {Object} An answer option object from the emoji question
+ */
 export const getSelectedEmoji = createSelector(
   getEmojiList,
   getSelected,
   (emojiList, selected) => emojiList.find(emoji => emoji.id === selected.emoji)
 );
 
+/**
+ * Get the currently selected topic answer object
+ *
+ * @returns {Object} An answer option object from the topic question
+ */
 export const getSelectedTopic = createSelector(
   getTopicList,
   getSelected,
   (topicList, selected) => topicList.find(topic => topic.id === selected.topic)
 );
 
+/**
+ * Get the currently selected topic emoji answer object (the second-dimension
+ * filter in bottom topic section)
+ *
+ * @returns {Object} An answer option object from the topic emoji question
+ */
 export const getSelectedTopicEmoji = createSelector(
   getEmojiList,
   getSelected,
@@ -164,6 +201,11 @@ export const getEmojiCountsFilteredByTopic = createSelector(
   }
 );
 
+/**
+ * Get the letter to display in the Topic filter section
+ *
+ * @returns {Object} A response letter object
+ */
 export const getEmojiLetter = createSelector(
   getResponses,
   getSelected,
@@ -173,11 +215,34 @@ export const getEmojiLetter = createSelector(
     if (!emojiId) {
       return null;
     }
-    const letterId = selectedResponses[emojiId];
-    return responses[letterId];
+    return responses[selectedResponses[emojiId]];
   }
 );
 
+/**
+ * Returns the number of available letters for the current Emoji section filters
+ * (does not apply when no emoji is selected; use available response list count
+ * in that instance)
+ *
+ * @returns {Number} An integer count of available responses
+ */
+export const getEmojiLetterCount = createSelector(
+  getAggregations,
+  getSelected,
+  (aggregations, selected) => {
+    const emojiId = selected.emoji;
+    if (!emojiId) {
+      return 0;
+    }
+    return aggregations[emojiId] ? aggregations[emojiId].count : 0;
+  }
+);
+
+/**
+ * Get the letter to display in the Topic section
+ *
+ * @returns {Object} A response letter object
+ */
 export const getTopicLetter = createSelector(
   getResponses,
   getSelected,
@@ -192,5 +257,26 @@ export const getTopicLetter = createSelector(
       return responses[selectedResponses[topicId]];
     }
     return responses[selectedResponses[combineIds(topicId, emojiId)]];
+  }
+);
+
+/**
+ * Returns the number of available letters for the current Topic section filters
+ *
+ * @returns {Number} An integer count of available responses
+ */
+export const getTopicLetterCount = createSelector(
+  getAggregations,
+  getSelected,
+  (aggregations, selected) => {
+    const topicId = selected.topic;
+    const emojiId = selected.topicEmoji;
+    if (!topicId || !aggregations[topicId]) {
+      return 0;
+    }
+    if (!emojiId) {
+      return aggregations[topicId].count || 0;
+    }
+    return aggregations[topicId][emojiId] ? aggregations[topicId][emojiId].count : 0;
   }
 );


### PR DESCRIPTION
Fixes #131 

- Adds selectors for available letter count from aggregation data
- Uses those selectors in views to conditionally disable the button
- Added doc blocks for undocumented selectors

This got held up by confusion around a bug in Ask's JSON aggregation export, but is now ready for review